### PR TITLE
refactor: Top bar always visible

### DIFF
--- a/src/__tests__/widgets/menu.test.tsx
+++ b/src/__tests__/widgets/menu.test.tsx
@@ -49,7 +49,7 @@ it('renders correctly', () => {
         class="sc-kLgntA hmuPEi"
       >
         <nav
-          class="sc-iktFzd jjwJYC"
+          class="sc-iktFzd dcjTPd"
         >
           <div
             class="sc-gsTCUz sc-dlfnbm jLyPtw byPlie"
@@ -119,7 +119,7 @@ it('renders correctly', () => {
           class="sc-jJEJSO hYddnZ"
         >
           <div
-            class="sc-dmlrTW kiUUDh"
+            class="sc-dmlrTW dvkfLy"
           >
             <div
               class="sc-kEjbxe fnkFQx"
@@ -496,7 +496,7 @@ it('renders correctly', () => {
             </div>
           </div>
           <div
-            class="sc-hiSbYr crsCoN"
+            class="sc-hiSbYr hHwNRW"
           >
             body
           </div>

--- a/src/widgets/Menu/Menu.tsx
+++ b/src/widgets/Menu/Menu.tsx
@@ -75,7 +75,6 @@ const Menu: React.FC<NavProps> = ({
   const { isXl } = useMatchBreakpoints();
   const isMobile = isXl === false;
   const [isPushed, setIsPushed] = useState(!isMobile);
-  const refPrevOffset = useRef(window.pageYOffset);
 
   // Find the home link if provided
   const homeLink = links.find((link) => link.label === 'Home');

--- a/src/widgets/Menu/Menu.tsx
+++ b/src/widgets/Menu/Menu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import Overlay from '../../components/Overlay/Overlay';
 import Flex from '../../components/Box/Flex';

--- a/src/widgets/Menu/Menu.tsx
+++ b/src/widgets/Menu/Menu.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
-import throttle from 'lodash/throttle';
 import Overlay from '../../components/Overlay/Overlay';
 import Flex from '../../components/Box/Flex';
 import { useMatchBreakpoints } from '../../hooks';
@@ -16,11 +15,10 @@ const Wrapper = styled.div`
   width: 100%;
 `;
 
-const StyledNav = styled.nav<{ showMenu: boolean }>`
+const StyledNav = styled.nav`
   position: fixed;
-  top: ${({ showMenu }) => (showMenu ? 0 : `-${MENU_HEIGHT}px`)};
+  top: 0;
   left: 0;
-  transition: top 0.2s;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -39,10 +37,9 @@ const BodyWrapper = styled.div`
   display: flex;
 `;
 
-const Inner = styled.div<{ isPushed: boolean; showMenu: boolean }>`
+const Inner = styled.div<{ isPushed: boolean }>`
   flex-grow: 1;
-  margin-top: ${({ showMenu }) => (showMenu ? `${MENU_HEIGHT}px` : 0)};
-  transition: margin-top 0.2s;
+  margin-top: ${MENU_HEIGHT}px;
   transform: translate3d(0, 0, 0);
   max-width: 100%;
 
@@ -78,44 +75,14 @@ const Menu: React.FC<NavProps> = ({
   const { isXl } = useMatchBreakpoints();
   const isMobile = isXl === false;
   const [isPushed, setIsPushed] = useState(!isMobile);
-  const [showMenu, setShowMenu] = useState(true);
   const refPrevOffset = useRef(window.pageYOffset);
-
-  useEffect(() => {
-    const handleScroll = () => {
-      const currentOffset = window.pageYOffset;
-      const isBottomOfPage = window.document.body.clientHeight === currentOffset + window.innerHeight;
-      const isTopOfPage = currentOffset === 0;
-      // Always show the menu when user reach the top
-      if (isTopOfPage) {
-        setShowMenu(true);
-      }
-      // Avoid triggering anything at the bottom because of layout shift
-      else if (!isBottomOfPage) {
-        if (currentOffset < refPrevOffset.current) {
-          // Has scroll up
-          setShowMenu(true);
-        } else {
-          // Has scroll down
-          setShowMenu(false);
-        }
-      }
-      refPrevOffset.current = currentOffset;
-    };
-    const throttledHandleScroll = throttle(handleScroll, 200);
-
-    window.addEventListener('scroll', throttledHandleScroll);
-    return () => {
-      window.removeEventListener('scroll', throttledHandleScroll);
-    };
-  }, []);
 
   // Find the home link if provided
   const homeLink = links.find((link) => link.label === 'Home');
 
   return (
     <Wrapper>
-      <StyledNav showMenu={showMenu}>
+      <StyledNav>
         <Logo
           isPushed={isPushed}
           togglePush={() => setIsPushed((prevState: boolean) => !prevState)}
@@ -131,7 +98,6 @@ const Menu: React.FC<NavProps> = ({
         <Panel
           isPushed={isPushed}
           isMobile={isMobile}
-          showMenu={showMenu}
           isDark={isDark}
           toggleTheme={toggleTheme}
           langs={langs}
@@ -141,9 +107,7 @@ const Menu: React.FC<NavProps> = ({
           pushNav={setIsPushed}
           links={links}
         />
-        <Inner isPushed={isPushed} showMenu={showMenu}>
-          {children}
-        </Inner>
+        <Inner isPushed={isPushed}>{children}</Inner>
         <MobileOnlyOverlay show={isPushed} onClick={() => setIsPushed(false)} role="presentation" />
       </BodyWrapper>
     </Wrapper>

--- a/src/widgets/Menu/components/Panel.tsx
+++ b/src/widgets/Menu/components/Panel.tsx
@@ -6,13 +6,12 @@ import { SIDEBAR_WIDTH_REDUCED, SIDEBAR_WIDTH_FULL } from '../config';
 import { PanelProps, PushedProps } from '../types';
 
 interface Props extends PanelProps, PushedProps {
-  showMenu: boolean;
   isMobile: boolean;
 }
 
-const StyledPanel = styled.div<{ isPushed: boolean; showMenu: boolean }>`
+const StyledPanel = styled.div<{ isPushed: boolean }>`
   position: fixed;
-  padding-top: ${({ showMenu }) => (showMenu ? '80px' : 0)};
+  padding-top: '80px';
   top: 0;
   left: 0;
   display: flex;
@@ -35,9 +34,9 @@ const StyledPanel = styled.div<{ isPushed: boolean; showMenu: boolean }>`
 `;
 
 const Panel: React.FC<Props> = (props) => {
-  const { isPushed, showMenu } = props;
+  const { isPushed } = props;
   return (
-    <StyledPanel isPushed={isPushed} showMenu={showMenu}>
+    <StyledPanel isPushed={isPushed}>
       <PanelBody {...props} />
       <PanelFooter {...props} />
     </StyledPanel>


### PR DESCRIPTION
Top bar always visible, even on scroll. It's not nice to hide the top bar when you do some scroll because it hides important information (wallet address).

Please, feel free to close if you like that effect.