### PR TITLE
Feat: Add useTooltip hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,9 +81,11 @@
     "styled-components": "^5.2.0"
   },
   "dependencies": {
+    "@popperjs/core": "^2.9.2",
     "@types/lodash": "^4.14.162",
     "@types/styled-system": "^5.1.10",
     "lodash": "^4.17.20",
+    "react-popper": "^2.2.5",
     "react-transition-group": "^4.4.1",
     "styled-system": "^5.1.5"
   }

--- a/src/__tests__/widgets/menu.test.tsx
+++ b/src/__tests__/widgets/menu.test.tsx
@@ -47,21 +47,21 @@ it('renders correctly', () => {
   expect(asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>
       <div
-        class="sc-kLgntA hmuPEi"
+        class="sc-jJEJSO jPLnEW"
       >
         <nav
-          class="sc-iktFzd XwCfb"
+          class="sc-hiSbYr iMHNYy"
         >
           <div
             class="sc-bdfBwQ sc-gsTCUz iwJkGQ ckYhbt"
           >
             <button
               aria-label="Toggle menu"
-              class="sc-pFZIQ bbzmsw sc-jrAGrp bQWwvU"
+              class="sc-kEjbxe gSpWKH sc-iqHYGH gOUsNC"
               scale="md"
             >
               <svg
-                class="sc-gKsewC kIBFDq"
+                class="sc-fubCfw jNjWDf"
                 color="textSubtle"
                 viewBox="0 0 24 24"
                 width="24px"
@@ -74,11 +74,11 @@ it('renders correctly', () => {
             </button>
             <a
               aria-label="ballena.io home page"
-              class="sc-kEjbxe hTKwD"
+              class="sc-crrsfI blBAFL"
               href="/"
             >
               <svg
-                class="sc-gKsewC ltlkO mobile-icon"
+                class="sc-fubCfw bxnML mobile-icon"
                 color="text"
                 viewBox="0 0 30 26"
                 width="20px"
@@ -90,7 +90,7 @@ it('renders correctly', () => {
                 />
               </svg>
               <svg
-                class="sc-gKsewC ltlkO desktop-icon"
+                class="sc-fubCfw bxnML desktop-icon"
                 color="text"
                 viewBox="0 0 116 26"
                 width="20px"
@@ -107,12 +107,12 @@ it('renders correctly', () => {
             class="sc-bdfBwQ sc-gsTCUz iwJkGQ cShFkN"
           >
             <a
-              class="sc-fubCfw kAsmGF"
+              class="sc-jrAGrp hKMsia"
               href=""
               target="_blank"
             >
               <svg
-                class="sc-gKsewC fHuKHU"
+                class="sc-fubCfw lePvUh"
                 color="text"
                 viewBox="0 0 26 26"
                 width="24px"
@@ -150,7 +150,7 @@ it('renders correctly', () => {
                 />
               </svg>
               <div
-                class="sc-iBPRYJ bcFJuZ"
+                class="sc-pFZIQ kLrxOT"
                 color="textSubtle"
               >
                 $0.232
@@ -158,7 +158,7 @@ it('renders correctly', () => {
             </a>
             <div>
               <button
-                class="sc-pFZIQ deLYMR"
+                class="sc-kEjbxe gjhA-DO"
                 scale="sm"
               >
                 0xbd...c980
@@ -167,16 +167,16 @@ it('renders correctly', () => {
           </div>
         </nav>
         <div
-          class="sc-jJEJSO hYddnZ"
+          class="sc-gWHgXt gKIFCh"
         >
           <div
-            class="sc-kfzAmx fBbLDf"
+            class="sc-bBXqnf kxrZfN"
           >
             <div
-              class="sc-kstrdz bYqKmK"
+              class="sc-fodVxV jbZrFL"
             >
               <div
-                class="sc-crrsfI jYJVrb"
+                class="sc-bqyKva cAOthW"
                 role="button"
               >
                 <a
@@ -186,7 +186,7 @@ it('renders correctly', () => {
                   target="_self"
                 >
                   <svg
-                    class="sc-gKsewC ltlkO"
+                    class="sc-fubCfw bxnML"
                     color="text"
                     viewBox="0 0 24 24"
                     width="24px"
@@ -212,14 +212,14 @@ it('renders correctly', () => {
                     />
                   </svg>
                   <div
-                    class="sc-iqHYGH jlLnSr"
+                    class="sc-dQppl ibSLUg"
                   >
                     Home
                   </div>
                 </a>
               </div>
               <div
-                class="sc-crrsfI gRZQNm"
+                class="sc-bqyKva dKJAtv"
                 role="button"
               >
                 <a
@@ -227,7 +227,7 @@ it('renders correctly', () => {
                   target="_self"
                 >
                   <svg
-                    class="sc-gKsewC ltlkO"
+                    class="sc-fubCfw bxnML"
                     color="text"
                     viewBox="0 0 24 24"
                     width="24px"
@@ -261,14 +261,14 @@ it('renders correctly', () => {
                     />
                   </svg>
                   <div
-                    class="sc-iqHYGH jlLnSr"
+                    class="sc-dQppl ibSLUg"
                   >
                     Vaults
                   </div>
                 </a>
               </div>
               <div
-                class="sc-crrsfI gRZQNm"
+                class="sc-bqyKva dKJAtv"
                 role="button"
               >
                 <a
@@ -276,7 +276,7 @@ it('renders correctly', () => {
                   target="_self"
                 >
                   <svg
-                    class="sc-gKsewC ltlkO"
+                    class="sc-fubCfw bxnML"
                     color="text"
                     viewBox="0 0 24 24"
                     width="24px"
@@ -299,14 +299,14 @@ it('renders correctly', () => {
                     />
                   </svg>
                   <div
-                    class="sc-iqHYGH jlLnSr"
+                    class="sc-dQppl ibSLUg"
                   >
                     Migration
                   </div>
                 </a>
               </div>
               <div
-                class="sc-crrsfI gRZQNm"
+                class="sc-bqyKva dKJAtv"
                 role="button"
               >
                 <a
@@ -314,7 +314,7 @@ it('renders correctly', () => {
                   target="_blank"
                 >
                   <svg
-                    class="sc-gKsewC ltlkO"
+                    class="sc-fubCfw bxnML"
                     color="text"
                     viewBox="0 0 24 24"
                     width="24px"
@@ -334,14 +334,14 @@ it('renders correctly', () => {
                     />
                   </svg>
                   <div
-                    class="sc-iqHYGH jlLnSr"
+                    class="sc-dQppl ibSLUg"
                   >
                     Docs
                   </div>
                 </a>
               </div>
               <div
-                class="sc-crrsfI gRZQNm"
+                class="sc-bqyKva dKJAtv"
                 role="button"
               >
                 <a
@@ -349,7 +349,7 @@ it('renders correctly', () => {
                   target="_blank"
                 >
                   <svg
-                    class="sc-gKsewC ltlkO"
+                    class="sc-fubCfw bxnML"
                     color="text"
                     viewBox="0 0 24 24"
                     width="24px"
@@ -373,7 +373,7 @@ it('renders correctly', () => {
                     />
                   </svg>
                   <div
-                    class="sc-iqHYGH jlLnSr"
+                    class="sc-dQppl ibSLUg"
                   >
                     Vote
                   </div>
@@ -381,24 +381,24 @@ it('renders correctly', () => {
               </div>
             </div>
             <div
-              class="sc-dIUggk ggQtLk"
+              class="sc-dmlrTW fPisRD"
             >
               <div
-                class="sc-dmlrTW hNsnAn"
+                class="sc-fKFyDc hPvuUm"
               >
                 <div
-                  class="sc-bkzZxe ePArPG"
+                  class="sc-dIUggk iVANKd"
                 >
                   <a
                     aria-label="Github"
-                    class="sc-iBPRYJ sc-fFubgz lkIJIa guucnR"
+                    class="sc-pFZIQ sc-idOhPF jbeWlA iKSIwH"
                     color="primary"
                     href="https://github.com/ballena-io"
                     rel="noreferrer noopener"
                     target="_blank"
                   >
                     <svg
-                      class="sc-gKsewC ltlkO"
+                      class="sc-fubCfw bxnML"
                       color="icon"
                       style="cursor: pointer;"
                       viewBox="0 0 24 24"
@@ -412,10 +412,10 @@ it('renders correctly', () => {
                     </svg>
                   </a>
                   <div
-                    class="sc-fodVxV hBablb"
+                    class="sc-bkzZxe kEyEBW"
                   >
                     <svg
-                      class="sc-gKsewC zHNoB"
+                      class="sc-fubCfw hMiuNI"
                       color="icon"
                       style="cursor: pointer;"
                       viewBox="0 0 24 24"
@@ -436,11 +436,11 @@ it('renders correctly', () => {
                       />
                     </svg>
                     <div
-                      class="sc-hBEYos jBqCvC"
+                      class="sc-fFubgz bQTaMO"
                     >
                       <a
                         aria-label="English"
-                        class="sc-iBPRYJ sc-fFubgz YIMWx guucnR"
+                        class="sc-pFZIQ sc-idOhPF hTTmwb iKSIwH"
                         color="icon"
                         href="https://ballena.medium.com"
                         rel="noreferrer noopener"
@@ -450,7 +450,7 @@ it('renders correctly', () => {
                       </a>
                       <a
                         aria-label="Español"
-                        class="sc-iBPRYJ sc-fFubgz YIMWx guucnR"
+                        class="sc-pFZIQ sc-idOhPF hTTmwb iKSIwH"
                         color="icon"
                         href="https://ballenaioe.medium.com"
                         rel="noreferrer noopener"
@@ -461,10 +461,10 @@ it('renders correctly', () => {
                     </div>
                   </div>
                   <div
-                    class="sc-fodVxV hBablb"
+                    class="sc-bkzZxe kEyEBW"
                   >
                     <svg
-                      class="sc-gKsewC zHNoB"
+                      class="sc-fubCfw hMiuNI"
                       color="icon"
                       style="cursor: pointer;"
                       viewBox="0 0 24 24"
@@ -476,11 +476,11 @@ it('renders correctly', () => {
                       />
                     </svg>
                     <div
-                      class="sc-hBEYos jBqCvC"
+                      class="sc-fFubgz bQTaMO"
                     >
                       <a
                         aria-label="English"
-                        class="sc-iBPRYJ sc-fFubgz YIMWx guucnR"
+                        class="sc-pFZIQ sc-idOhPF hTTmwb iKSIwH"
                         color="icon"
                         href="https://t.me/ballenaenglish"
                         rel="noreferrer noopener"
@@ -490,7 +490,7 @@ it('renders correctly', () => {
                       </a>
                       <a
                         aria-label="Español"
-                        class="sc-iBPRYJ sc-fFubgz YIMWx guucnR"
+                        class="sc-pFZIQ sc-idOhPF hTTmwb iKSIwH"
                         color="icon"
                         href="https://t.me/ballenaspanish"
                         rel="noreferrer noopener"
@@ -501,10 +501,10 @@ it('renders correctly', () => {
                     </div>
                   </div>
                   <div
-                    class="sc-fodVxV hBablb"
+                    class="sc-bkzZxe kEyEBW"
                   >
                     <svg
-                      class="sc-gKsewC zHNoB"
+                      class="sc-fubCfw hMiuNI"
                       color="icon"
                       style="cursor: pointer;"
                       viewBox="0 0 24 24"
@@ -516,11 +516,11 @@ it('renders correctly', () => {
                       />
                     </svg>
                     <div
-                      class="sc-hBEYos jBqCvC"
+                      class="sc-fFubgz bQTaMO"
                     >
                       <a
                         aria-label="English"
-                        class="sc-iBPRYJ sc-fFubgz YIMWx guucnR"
+                        class="sc-pFZIQ sc-idOhPF hTTmwb iKSIwH"
                         color="icon"
                         href="https://twitter.com/ballenaio"
                         rel="noreferrer noopener"
@@ -530,7 +530,7 @@ it('renders correctly', () => {
                       </a>
                       <a
                         aria-label="Español"
-                        class="sc-iBPRYJ sc-fFubgz YIMWx guucnR"
+                        class="sc-pFZIQ sc-idOhPF hTTmwb iKSIwH"
                         color="icon"
                         href="https://twitter.com/BallenaioE"
                         rel="noreferrer noopener"
@@ -543,160 +543,160 @@ it('renders correctly', () => {
                 </div>
               </div>
               <div
-                class="sc-hHftDr cnPTSb"
+                class="sc-kfzAmx bdVoEU"
               >
                 <div
-                  class="sc-fodVxV hBablb"
+                  class="sc-bkzZxe kEyEBW"
                 >
                   <button
-                    class="sc-pFZIQ lnQbPX"
+                    class="sc-kEjbxe cQiAIs"
                     scale="md0"
                   >
                     <div
-                      class="sc-iBPRYJ yGQvr"
+                      class="sc-pFZIQ itViXh"
                       color="icon"
                     >
                       EN
                     </div>
                   </button>
                   <div
-                    class="sc-hBEYos jBqCvC"
+                    class="sc-fFubgz bQTaMO"
                   >
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English0
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English1
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English2
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English3
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English4
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English5
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English6
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English7
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English8
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English9
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English10
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English11
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English12
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English13
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English14
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English15
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English16
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English17
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
                       English18
                     </button>
                     <button
-                      class="sc-pFZIQ ekeHxg sc-jrAGrp bQWwvU"
+                      class="sc-kEjbxe fcPGIf sc-iqHYGH gOUsNC"
                       scale="md"
                       style="min-height: 32px; height: auto;"
                     >
@@ -705,11 +705,11 @@ it('renders correctly', () => {
                   </div>
                 </div>
                 <button
-                  class="sc-pFZIQ lnQbPX sc-idOhPF lgUvgS"
+                  class="sc-kEjbxe cQiAIs sc-hHftDr cRIOLi"
                   scale="md0"
                 >
                   <svg
-                    class="sc-gKsewC ltlkO"
+                    class="sc-fubCfw bxnML"
                     color="icon"
                     viewBox="0 0 24 24"
                     width="24px"
@@ -750,12 +750,12 @@ it('renders correctly', () => {
             </div>
           </div>
           <div
-            class="sc-hiSbYr dNmlwx"
+            class="sc-cBNfnY dSqjgY"
           >
             body
           </div>
           <div
-            class="sc-dlfnbm sc-gWHgXt kgrCKx IZmxf"
+            class="sc-dlfnbm sc-citwmv kgrCKx GCzmW"
             role="presentation"
           />
         </div>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useMatchBreakpoints } from './useMatchBreakpoints';
 export { default as useParticleBurst } from './useParticleBurst';
 export { default as useKonamiCheatCode } from './useKonamiCheatCode';
+export * from './useTooltip';

--- a/src/hooks/useTooltip/StyledTooltip.tsx
+++ b/src/hooks/useTooltip/StyledTooltip.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+
+export const Arrow = styled.div`
+  &,
+  &::before {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    z-index: -1;
+  }
+  &::before {
+    content: '';
+    transform: rotate(45deg);
+    background: ${({ theme }) => theme.tooltip.background};
+  }
+`;
+
+export const StyledTooltip = styled.div`
+  padding: 16px;
+  font-size: 16px;
+  line-height: 130%;
+  border-radius: 16px;
+  max-width: 320px;
+  background: ${({ theme }) => theme.tooltip.background};
+  color: ${({ theme }) => theme.tooltip.text};
+  box-shadow: ${({ theme }) => theme.tooltip.boxShadow};
+  &[data-popper-placement^='top'] > ${Arrow} {
+    bottom: -4px;
+  }
+  &[data-popper-placement^='bottom'] > ${Arrow} {
+    top: -4px;
+  }
+  &[data-popper-placement^='left'] > ${Arrow} {
+    right: -4px;
+  }
+  &[data-popper-placement^='right'] > ${Arrow} {
+    left: -4px;
+  }
+`;

--- a/src/hooks/useTooltip/index.tsx
+++ b/src/hooks/useTooltip/index.tsx
@@ -1,0 +1,2 @@
+export { default as useTooltip } from './useTooltip';
+export type { TooltipRefs, TriggerType } from './types';

--- a/src/hooks/useTooltip/types.ts
+++ b/src/hooks/useTooltip/types.ts
@@ -1,0 +1,7 @@
+export interface TooltipRefs {
+  targetRef: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
+  tooltip: React.ReactNode;
+  tooltipVisible: boolean;
+}
+
+export type TriggerType = 'click' | 'hover' | 'focus';

--- a/src/hooks/useTooltip/useTooltip.stories.tsx
+++ b/src/hooks/useTooltip/useTooltip.stories.tsx
@@ -1,0 +1,305 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Input from '../../components/Input/Input';
+import Text from '../../components/Text/Text';
+import HelpIcon from '../../components/Svg/Icons/Help';
+import useTooltip from './useTooltip';
+
+const GridCell = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ReferenceElement = styled.div`
+  background-color: #1fc7d4;
+  width: 160px;
+  height: 160px;
+  border-radius: 8px;
+`;
+
+const Container = styled.div`
+  padding: 64px 120px;
+  display: grid;
+  grid-template-columns: repeat(3, 200px);
+  grid-template-rows: repeat(4, 200px);
+`;
+
+const ExpandableCard = styled.div`
+  width: 300px;
+  margin: 0 auto;
+  padding: 0 10px;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: rgba(70, 70, 80, 0.2) 0px 7px 29px 0px;
+`;
+
+const ExpandableHeader = styled.div`
+  height: 40px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export default {
+  title: 'Hooks/useTooltip',
+};
+
+export const Placement: React.FC = () => {
+  // TOP
+  const { targetRef: targetRefTopStart, tooltip: tooltipTopStart } = useTooltip('top-start', 'top-start', 'click');
+  const { targetRef: targetRefTop, tooltip: tooltipTop } = useTooltip('top', 'top', 'click');
+  const { targetRef: targetRefTopEnd, tooltip: tooltipTopEnd } = useTooltip('top-end', 'top-end', 'click');
+  // LEFT
+  const { targetRef: targetRefLeftStart, tooltip: tooltipLeftStart } = useTooltip('left-start', 'left-start', 'click');
+  const { targetRef: targetRefLeft, tooltip: tooltipLeft } = useTooltip('left', 'left', 'click');
+  const { targetRef: targetRefLeftEnd, tooltip: tooltipLeftEnd } = useTooltip('left-end', 'left-end', 'click');
+  // RIGHT
+  const { targetRef: targetRefRightStart, tooltip: tooltipRightStart } = useTooltip(
+    'right-start',
+    'right-start',
+    'click'
+  );
+  const { targetRef: targetRefRight, tooltip: tooltipRight } = useTooltip('right', 'right', 'click');
+  const { targetRef: targetRefRightEnd, tooltip: tooltipRightEnd } = useTooltip('right-end', 'right-end', 'click');
+  // BOTTOM
+  const { targetRef: targetRefBottomStart, tooltip: tooltipBottomStart } = useTooltip(
+    'bottom-start',
+    'bottom-start',
+    'click'
+  );
+  const { targetRef: targetRefBottom, tooltip: tooltipBottom } = useTooltip('bottom', 'bottom', 'click');
+  const { targetRef: targetRefBottomEnd, tooltip: tooltipBottomEnd } = useTooltip('bottom-end', 'bottom-end', 'click');
+
+  return (
+    <Container>
+      <GridCell>
+        <ReferenceElement ref={targetRefTopStart} />
+        {tooltipTopStart}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefTop} />
+        {tooltipTop}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefTopEnd} />
+        {tooltipTopEnd}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefLeftStart} />
+        {tooltipLeftStart}
+      </GridCell>
+      <div />
+      <GridCell>
+        <ReferenceElement ref={targetRefRightStart} />
+        {tooltipRightStart}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefLeft} />
+        {tooltipLeft}
+      </GridCell>
+      <div />
+      <GridCell>
+        <ReferenceElement ref={targetRefRight} />
+        {tooltipRight}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefLeftEnd} />
+        {tooltipLeftEnd}
+      </GridCell>
+      <div />
+      <GridCell>
+        <ReferenceElement ref={targetRefRightEnd} />
+        {tooltipRightEnd}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefBottomStart} />
+        {tooltipBottomStart}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefBottom} />
+        {tooltipBottom}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefBottomEnd} />
+        {tooltipBottomEnd}
+      </GridCell>
+    </Container>
+  );
+};
+
+export const Triggers: React.FC = () => {
+  const { tooltipVisible: tooltipVisibleClick, targetRef: targetRefClick, tooltip: tooltipClick } = useTooltip(
+    'You clicked me!',
+    'right',
+    'click'
+  );
+  const { tooltipVisible: tooltipVisibleHover, targetRef: targetRefHover, tooltip: tooltipHover } = useTooltip(
+    'Hovering',
+    'right',
+    'hover'
+  );
+
+  const { tooltipVisible: tooltipVisibleFocus, targetRef: targetRefFocus, tooltip: tooltipFocus } = useTooltip(
+    'You focused me!',
+    'right',
+    'focus'
+  );
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '300px',
+        width: '200px',
+        justifyContent: 'space-evenly',
+      }}
+    >
+      <Input ref={targetRefClick} placeholder="click" />
+      {tooltipVisibleClick && tooltipClick}
+      <Input ref={targetRefHover} placeholder="hover" />
+      {tooltipVisibleHover && tooltipHover}
+      <Input ref={targetRefFocus} placeholder="focus" />
+      {tooltipVisibleFocus && tooltipFocus}
+    </div>
+  );
+};
+
+export const EventPropagationAndMobile: React.FC = () => {
+  const [showExpandedClick, setShowExpandedClick] = useState(false);
+  const [showExpandedHover, setShowExpandedHover] = useState(false);
+  const { tooltipVisible: tooltipVisibleClick, targetRef: targetRefClick, tooltip: tooltipClick } = useTooltip(
+    'You clicked on the help icon but the card did not expand',
+    'right',
+    'click'
+  );
+  const { tooltipVisible: tooltipVisibleHover, targetRef: targetRefHover, tooltip: tooltipHover } = useTooltip(
+    'You hovered over the help icon',
+    'right',
+    'hover'
+  );
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '600px',
+        width: '500px',
+        justifyContent: 'space-evenly',
+      }}
+    >
+      <Text>
+        Events do not propagate to other elements in the tree. This helps to not cause unwanted bahaviour like expanding
+        the cards when clicking on the tooltip target.
+      </Text>
+
+      <ExpandableCard onClick={() => setShowExpandedClick(!showExpandedClick)}>
+        <ExpandableHeader>
+          On click {showExpandedClick ? '▴' : '▾'}
+          <span ref={targetRefClick}>
+            <HelpIcon />
+          </span>
+        </ExpandableHeader>
+        {showExpandedClick && (
+          <div style={{ margin: '15px 0' }}>You clicked on the header but not on the help icon inside the header</div>
+        )}
+        {tooltipVisibleClick && tooltipClick}
+      </ExpandableCard>
+      <Text>
+        On touch screen devices hover interactions are also properly handled with `touchstart` and `touchend` events
+        (`mouseenter` and `mouseleave` cause unwated behaviour on some mobile browsers).
+      </Text>
+      <ExpandableCard onClick={() => setShowExpandedHover(!showExpandedHover)}>
+        <ExpandableHeader>
+          On hover {showExpandedHover ? '▴' : '▾'}
+          <span ref={targetRefHover}>
+            <HelpIcon />
+          </span>
+        </ExpandableHeader>
+        {showExpandedHover && (
+          <div style={{ margin: '15px 0' }}>
+            On mobile hovering (or more specifically touching and holding) over the help icon does not trigger expansion
+            of this card
+          </div>
+        )}
+        {tooltipVisibleHover && tooltipHover}
+      </ExpandableCard>
+    </div>
+  );
+};
+
+export const FineTuning: React.FC = () => {
+  const { tooltipVisible: tooltipVisibleDefault, targetRef: targetRefDefault, tooltip: tooltipDefault } = useTooltip(
+    'Just default tooltip',
+    'top-start',
+    'hover'
+  );
+  const {
+    tooltipVisible: tooltipVisibleFineTuned,
+    targetRef: targetRefFineTuned,
+    tooltip: tooltipFineTuned,
+  } = useTooltip("Didn't you know that 6 comes before 7?", 'top-start', 'hover', { right: 221 }, undefined, [0, -8]);
+  return (
+    <div style={{ width: '500px', height: '500px' }}>
+      <Text fontSize="20px">Hover over inputs</Text>
+      <Text bold>Default placement</Text>
+      <Input ref={targetRefDefault} value="0x1234567890000" />
+      {tooltipVisibleDefault && tooltipDefault}
+      <Text bold>Fine tuned arrow placement</Text>
+      <Input ref={targetRefFineTuned} value="0x1234576890000" />
+      {tooltipVisibleFineTuned && tooltipFineTuned}
+    </div>
+  );
+};
+
+export const Flipping: React.FC = () => {
+  const { targetRef, tooltip } = useTooltip('All tooltips flip automatically when you scroll', 'top', 'hover');
+  return (
+    <div style={{ padding: '200px', width: '500px', height: '2000px' }}>
+      <ReferenceElement ref={targetRef} />
+      {tooltip}
+    </div>
+  );
+};
+
+export const ScreenEdges: React.FC = () => {
+  const { targetRef: targetRefLeft, tooltip: tooltipLeft, tooltipVisible: leftVisible } = useTooltip(
+    'I should not touch the edge of the screen',
+    'top',
+    'click'
+  );
+  const { targetRef: targetRefRight, tooltip: tooltipRight, tooltipVisible: rightVisible } = useTooltip(
+    'I should not touch the edge of the screen',
+    'top',
+    'click'
+  );
+  const { targetRef: targetRefMiddle, tooltip: tooltipMiddle, tooltipVisible: middleVisible } = useTooltip(
+    'I should not touch the edge of the screen',
+    'top',
+    'click'
+  );
+  return (
+    <div style={{ padding: '16px', height: '800px', backgroundColor: '#EEE' }}>
+      <Text>
+        This story can be used to visually tooltip behavior when the target element is positioned close to the screen
+        edge. Open this screen on the phone or in browser with responsive mode. Tooltips should not touch the screen
+        edge.
+      </Text>
+      <div style={{ display: 'flex', justifyContent: 'space-between', padding: '24px' }}>
+        <span ref={targetRefLeft}>
+          <HelpIcon />
+        </span>
+        {leftVisible && tooltipLeft}
+        <span ref={targetRefMiddle}>
+          <HelpIcon />
+        </span>
+        {middleVisible && tooltipMiddle}
+        <span ref={targetRefRight}>
+          <HelpIcon />
+        </span>
+        {rightVisible && tooltipRight}
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/useTooltip/useTooltip.tsx
+++ b/src/hooks/useTooltip/useTooltip.tsx
@@ -1,0 +1,153 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Placement, Padding } from '@popperjs/core';
+import { usePopper } from 'react-popper';
+import { StyledTooltip, Arrow } from './StyledTooltip';
+import { TooltipRefs, TriggerType } from './types';
+
+function isTouchDevice() {
+  return 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
+}
+
+const useTooltip = (
+  content: React.ReactNode,
+  placement: Placement = 'auto',
+  trigger: TriggerType = 'hover',
+  arrowPadding?: Padding,
+  tooltipPadding?: Padding,
+  tooltipOffset?: [number, number]
+): TooltipRefs => {
+  const [targetElement, setTargetElement] = useState<HTMLElement | null>(null);
+  const [tooltipElement, setTooltipElement] = useState<HTMLElement | null>(null);
+  const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
+
+  const [visible, setVisible] = useState(false);
+
+  const hideTooltip = useCallback((e: Event) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setVisible(false);
+  }, []);
+
+  const showTooltip = useCallback((e: Event) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setVisible(true);
+  }, []);
+
+  const toggleTooltip = useCallback(
+    (e: Event) => {
+      e.stopPropagation();
+      setVisible(!visible);
+    },
+    [visible]
+  );
+
+  // Trigger = hover
+  useEffect(() => {
+    if (targetElement === null || trigger !== 'hover') return undefined;
+
+    if (isTouchDevice()) {
+      targetElement.addEventListener('touchstart', showTooltip);
+      targetElement.addEventListener('touchend', hideTooltip);
+    } else {
+      targetElement.addEventListener('mouseenter', showTooltip);
+      targetElement.addEventListener('mouseleave', hideTooltip);
+    }
+    return () => {
+      targetElement.removeEventListener('touchstart', showTooltip);
+      targetElement.removeEventListener('touchend', hideTooltip);
+      targetElement.removeEventListener('mouseenter', showTooltip);
+      targetElement.removeEventListener('mouseleave', showTooltip);
+    };
+  }, [trigger, targetElement, hideTooltip, showTooltip]);
+
+  // Keep tooltip open when cursor moves from the targetElement to the tooltip
+  useEffect(() => {
+    if (tooltipElement === null || trigger !== 'hover') return undefined;
+
+    tooltipElement.addEventListener('mouseenter', showTooltip);
+    tooltipElement.addEventListener('mouseleave', hideTooltip);
+    return () => {
+      tooltipElement.removeEventListener('mouseenter', showTooltip);
+      tooltipElement.removeEventListener('mouseleave', hideTooltip);
+    };
+  }, [trigger, tooltipElement, hideTooltip, showTooltip]);
+
+  // Trigger = click
+  useEffect(() => {
+    if (targetElement === null || trigger !== 'click') return undefined;
+
+    targetElement.addEventListener('click', toggleTooltip);
+
+    return () => targetElement.removeEventListener('click', toggleTooltip);
+  }, [trigger, targetElement, visible, toggleTooltip]);
+
+  // Handle click outside
+  useEffect(() => {
+    if (trigger !== 'click') return undefined;
+
+    const handleClickOutside = ({ target }: Event) => {
+      if (target instanceof Node) {
+        if (
+          tooltipElement != null &&
+          targetElement != null &&
+          !tooltipElement.contains(target) &&
+          !targetElement.contains(target)
+        ) {
+          setVisible(false);
+        }
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [trigger, targetElement, tooltipElement]);
+
+  // Trigger = focus
+  useEffect(() => {
+    if (targetElement === null || trigger !== 'focus') return undefined;
+
+    targetElement.addEventListener('focus', showTooltip);
+    targetElement.addEventListener('blur', hideTooltip);
+    return () => {
+      targetElement.removeEventListener('focus', showTooltip);
+      targetElement.removeEventListener('blur', hideTooltip);
+    };
+  }, [trigger, targetElement, showTooltip, hideTooltip]);
+
+  // On small screens Popper.js tries to squeeze the tooltip to available space without overflowing beyound the edge
+  // of the screen. While it works fine when the element is in the middle of the screen it does not handle well the
+  // cases when the target element is very close to the edge of the screen - no margin is applied between the tooltip
+  // and the screen edge.
+  // preventOverflow mitigates this behaviour, default 16px paddings on left and right solve the problem for all screen sizes
+  // that we support.
+  // Note that in the farm page where there are tooltips very close to the edge of the screen this padding works perfectly
+  // even on the iPhone 5 screen (320px wide), BUT in the storybook with the contrived example ScreenEdges example
+  // iPhone 5 behaves differently overflowing beyound the edge. All paddings are identical so I have no idea why it is,
+  // and fixing that seems like a very bad use of time.
+  const { styles, attributes } = usePopper(targetElement, tooltipElement, {
+    placement,
+    modifiers: [
+      {
+        name: 'arrow',
+        options: { element: arrowElement, padding: arrowPadding || 16 },
+      },
+      { name: 'offset', options: { offset: tooltipOffset || [0, 10] } },
+      { name: 'preventOverflow', options: { padding: tooltipPadding || { left: 16, right: 16 } } },
+    ],
+  });
+
+  const tooltip = (
+    <StyledTooltip ref={setTooltipElement} style={styles.popper} {...attributes.popper}>
+      {content}
+      <Arrow ref={setArrowElement} style={styles.arrow} />
+    </StyledTooltip>
+  );
+  return {
+    targetRef: setTargetElement,
+    tooltip,
+    tooltipVisible: visible,
+  };
+};
+
+export default useTooltip;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,6 +2289,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.6.0.tgz#f022195afdfc942e088ee2101285a1d31c7d727f"
   integrity sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==
 
+"@popperjs/core@^2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
+  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
+
 "@reach/router@^1.3.3":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -11777,6 +11782,14 @@ react-popper@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.4.tgz#d2ad3d2474ac9f1abf93df3099d408e5aa6a2e22"
   integrity sha512-NacOu4zWupdQjVXq02XpTD3yFPSfg5a7fex0wa3uGKVkFK7UN6LvVxgcb+xYr56UCuWiNPMH20tntdVdJRwYew==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
+
+react-popper@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
+  integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"


### PR DESCRIPTION
This PR adds useTooltip hook.

Uses Popper.js and react-popper to position tooltip.

Minimal example (on hover)

```
const { targetRef, tooltip, tooltipVisible } = useTooltip("Tooltip text", "top");
return (
    <>
      <button ref={targetRef}>hover me</button>
      {tooltipVisible && tooltip}
    </>
);
```