### PR TITLE
Feat: Add TextTooltip and tooltip improvements

### DIFF
--- a/src/__tests__/components/alert.test.tsx
+++ b/src/__tests__/components/alert.test.tsx
@@ -8,10 +8,10 @@ it('renders correctly', () => {
   expect(asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>
       <div
-        class="sc-bdfBwQ sc-gsTCUz sc-pFZIQ iwJkGQ ckYhbt ceoeSC"
+        class="sc-bdfBwQ sc-gsTCUz sc-jrAGrp iwJkGQ ckYhbt dnnRmK"
       >
         <div
-          class="sc-gKsewC kbDdBz"
+          class="sc-iBPRYJ hSlcZv"
         >
           <svg
             class="sc-eCssSg ekBOuV"
@@ -26,7 +26,7 @@ it('renders correctly', () => {
           </svg>
         </div>
         <div
-          class="sc-iBPRYJ hdYjNd"
+          class="sc-fubCfw eTZWPY"
         >
           <div
             class="sc-jSgupP jsnPHc"

--- a/src/components/Text/TooltipText.tsx
+++ b/src/components/Text/TooltipText.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+import Text from './Text';
+
+const TooltipText = styled(Text)`
+  text-decoration: ${({ theme }) => `underline dotted ${theme.colors.textSubtle}`};
+  text-underline-offset: 0.1em;
+`;
+
+export default TooltipText;

--- a/src/components/Text/index.stories.tsx
+++ b/src/components/Text/index.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Text from './Text';
+import TooltipText from './TooltipText';
 
 export default {
   title: 'Components/Text',
@@ -51,6 +52,15 @@ export const Default: React.FC = () => {
         with text transform
       </Text>
       <Text textAlign="center">center</Text>
+    </div>
+  );
+};
+
+export const TooltipTextVariant: React.FC = () => {
+  return (
+    <div>
+      <Text>Use TooltipText for text that has tooltip, it accepts the same props as normal Text component</Text>
+      <TooltipText>Example</TooltipText>
     </div>
   );
 };

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,2 +1,3 @@
 export { default as Text } from './Text';
 export type { TextProps } from './types';
+export { default as TooltipText } from './TooltipText';

--- a/src/hooks/useTooltip/types.ts
+++ b/src/hooks/useTooltip/types.ts
@@ -1,7 +1,17 @@
+import { Placement, Padding } from '@popperjs/core';
+
 export interface TooltipRefs {
   targetRef: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
   tooltip: React.ReactNode;
   tooltipVisible: boolean;
+}
+
+export interface TooltipOptions {
+  placement?: Placement;
+  trigger?: TriggerType;
+  arrowPadding?: Padding;
+  tooltipPadding?: Padding;
+  tooltipOffset?: [number, number];
 }
 
 export type TriggerType = 'click' | 'hover' | 'focus';

--- a/src/hooks/useTooltip/useTooltip.stories.tsx
+++ b/src/hooks/useTooltip/useTooltip.stories.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import Input from '../../components/Input/Input';
+import Toggle from '../../components/Toggle/Toggle';
 import Text from '../../components/Text/Text';
 import HelpIcon from '../../components/Svg/Icons/Help';
 import useTooltip from './useTooltip';
+import BalanceInput from '../../components/BalanceInput/BalanceInput';
 
 const GridCell = styled.div`
   display: flex;
@@ -47,30 +49,39 @@ export default {
 };
 
 export const Placement: React.FC = () => {
+  // Trigger doesn't matter in this story, it just shows tooltips no matter what
   // TOP
-  const { targetRef: targetRefTopStart, tooltip: tooltipTopStart } = useTooltip('top-start', 'top-start', 'click');
-  const { targetRef: targetRefTop, tooltip: tooltipTop } = useTooltip('top', 'top', 'click');
-  const { targetRef: targetRefTopEnd, tooltip: tooltipTopEnd } = useTooltip('top-end', 'top-end', 'click');
+  const { targetRef: targetRefTopStart, tooltip: tooltipTopStart } = useTooltip('top-start', {
+    placement: 'top-start',
+  });
+  const { targetRef: targetRefTop, tooltip: tooltipTop } = useTooltip('top', { placement: 'top' });
+  const { targetRef: targetRefTopEnd, tooltip: tooltipTopEnd } = useTooltip('top-end', {
+    placement: 'top-end',
+  });
   // LEFT
-  const { targetRef: targetRefLeftStart, tooltip: tooltipLeftStart } = useTooltip('left-start', 'left-start', 'click');
-  const { targetRef: targetRefLeft, tooltip: tooltipLeft } = useTooltip('left', 'left', 'click');
-  const { targetRef: targetRefLeftEnd, tooltip: tooltipLeftEnd } = useTooltip('left-end', 'left-end', 'click');
+  const { targetRef: targetRefLeftStart, tooltip: tooltipLeftStart } = useTooltip('left-start', {
+    placement: 'left-start',
+  });
+  const { targetRef: targetRefLeft, tooltip: tooltipLeft } = useTooltip('left', {
+    placement: 'left',
+  });
+  const { targetRef: targetRefLeftEnd, tooltip: tooltipLeftEnd } = useTooltip('left-end', { placement: 'left-end' });
   // RIGHT
-  const { targetRef: targetRefRightStart, tooltip: tooltipRightStart } = useTooltip(
-    'right-start',
-    'right-start',
-    'click'
-  );
-  const { targetRef: targetRefRight, tooltip: tooltipRight } = useTooltip('right', 'right', 'click');
-  const { targetRef: targetRefRightEnd, tooltip: tooltipRightEnd } = useTooltip('right-end', 'right-end', 'click');
+  const { targetRef: targetRefRightStart, tooltip: tooltipRightStart } = useTooltip('right-start', {
+    placement: 'right-start',
+  });
+  const { targetRef: targetRefRight, tooltip: tooltipRight } = useTooltip('right', { placement: 'right' });
+  const { targetRef: targetRefRightEnd, tooltip: tooltipRightEnd } = useTooltip('right-end', {
+    placement: 'right-end',
+  });
   // BOTTOM
-  const { targetRef: targetRefBottomStart, tooltip: tooltipBottomStart } = useTooltip(
-    'bottom-start',
-    'bottom-start',
-    'click'
-  );
-  const { targetRef: targetRefBottom, tooltip: tooltipBottom } = useTooltip('bottom', 'bottom', 'click');
-  const { targetRef: targetRefBottomEnd, tooltip: tooltipBottomEnd } = useTooltip('bottom-end', 'bottom-end', 'click');
+  const { targetRef: targetRefBottomStart, tooltip: tooltipBottomStart } = useTooltip('bottom-start', {
+    placement: 'bottom-start',
+  });
+  const { targetRef: targetRefBottom, tooltip: tooltipBottom } = useTooltip('bottom', { placement: 'bottom' });
+  const { targetRef: targetRefBottomEnd, tooltip: tooltipBottomEnd } = useTooltip('bottom-end', {
+    placement: 'bottom-end',
+  });
 
   return (
     <Container>
@@ -130,22 +141,22 @@ export const Placement: React.FC = () => {
 };
 
 export const Triggers: React.FC = () => {
-  const { tooltipVisible: tooltipVisibleClick, targetRef: targetRefClick, tooltip: tooltipClick } = useTooltip(
-    'You clicked me!',
-    'right',
-    'click'
-  );
-  const { tooltipVisible: tooltipVisibleHover, targetRef: targetRefHover, tooltip: tooltipHover } = useTooltip(
-    'Hovering',
-    'right',
-    'hover'
-  );
+  const {
+    tooltipVisible: tooltipVisibleClick,
+    targetRef: targetRefClick,
+    tooltip: tooltipClick,
+  } = useTooltip('You clicked me!', { placement: 'right', trigger: 'click' });
+  const {
+    tooltipVisible: tooltipVisibleHover,
+    targetRef: targetRefHover,
+    tooltip: tooltipHover,
+  } = useTooltip('Hovering', { placement: 'right', trigger: 'hover' });
 
-  const { tooltipVisible: tooltipVisibleFocus, targetRef: targetRefFocus, tooltip: tooltipFocus } = useTooltip(
-    'You focused me!',
-    'right',
-    'focus'
-  );
+  const {
+    tooltipVisible: tooltipVisibleFocus,
+    targetRef: targetRefFocus,
+    tooltip: tooltipFocus,
+  } = useTooltip('You focused me!', { placement: 'right', trigger: 'focus' });
   return (
     <div
       style={{
@@ -169,16 +180,16 @@ export const Triggers: React.FC = () => {
 export const EventPropagationAndMobile: React.FC = () => {
   const [showExpandedClick, setShowExpandedClick] = useState(false);
   const [showExpandedHover, setShowExpandedHover] = useState(false);
-  const { tooltipVisible: tooltipVisibleClick, targetRef: targetRefClick, tooltip: tooltipClick } = useTooltip(
-    'You clicked on the help icon but the card did not expand',
-    'right',
-    'click'
-  );
-  const { tooltipVisible: tooltipVisibleHover, targetRef: targetRefHover, tooltip: tooltipHover } = useTooltip(
-    'You hovered over the help icon',
-    'right',
-    'hover'
-  );
+  const {
+    tooltipVisible: tooltipVisibleClick,
+    targetRef: targetRefClick,
+    tooltip: tooltipClick,
+  } = useTooltip('You clicked on the help icon but the card did not expand', { placement: 'right', trigger: 'click' });
+  const {
+    tooltipVisible: tooltipVisibleHover,
+    targetRef: targetRefHover,
+    tooltip: tooltipHover,
+  } = useTooltip('You hovered over the help icon', { placement: 'right', trigger: 'hover' });
   return (
     <div
       style={{
@@ -230,16 +241,20 @@ export const EventPropagationAndMobile: React.FC = () => {
 };
 
 export const FineTuning: React.FC = () => {
-  const { tooltipVisible: tooltipVisibleDefault, targetRef: targetRefDefault, tooltip: tooltipDefault } = useTooltip(
-    'Just default tooltip',
-    'top-start',
-    'hover'
-  );
+  const {
+    tooltipVisible: tooltipVisibleDefault,
+    targetRef: targetRefDefault,
+    tooltip: tooltipDefault,
+  } = useTooltip('Just default tooltip', { placement: 'top-start' });
   const {
     tooltipVisible: tooltipVisibleFineTuned,
     targetRef: targetRefFineTuned,
     tooltip: tooltipFineTuned,
-  } = useTooltip("Didn't you know that 6 comes before 7?", 'top-start', 'hover', { right: 221 }, undefined, [0, -8]);
+  } = useTooltip("Didn't you know that 6 comes before 7?", {
+    placement: 'top-start',
+    arrowPadding: { right: 221 },
+    tooltipOffset: [0, -8],
+  });
   return (
     <div style={{ width: '500px', height: '500px' }}>
       <Text fontSize="20px">Hover over inputs</Text>
@@ -254,7 +269,7 @@ export const FineTuning: React.FC = () => {
 };
 
 export const Flipping: React.FC = () => {
-  const { targetRef, tooltip } = useTooltip('All tooltips flip automatically when you scroll', 'top', 'hover');
+  const { targetRef, tooltip } = useTooltip('All tooltips flip automatically when you scroll', { placement: 'top' });
   return (
     <div style={{ padding: '200px', width: '500px', height: '2000px' }}>
       <ReferenceElement ref={targetRef} />
@@ -264,21 +279,21 @@ export const Flipping: React.FC = () => {
 };
 
 export const ScreenEdges: React.FC = () => {
-  const { targetRef: targetRefLeft, tooltip: tooltipLeft, tooltipVisible: leftVisible } = useTooltip(
-    'I should not touch the edge of the screen',
-    'top',
-    'click'
-  );
-  const { targetRef: targetRefRight, tooltip: tooltipRight, tooltipVisible: rightVisible } = useTooltip(
-    'I should not touch the edge of the screen',
-    'top',
-    'click'
-  );
-  const { targetRef: targetRefMiddle, tooltip: tooltipMiddle, tooltipVisible: middleVisible } = useTooltip(
-    'I should not touch the edge of the screen',
-    'top',
-    'click'
-  );
+  const {
+    targetRef: targetRefLeft,
+    tooltip: tooltipLeft,
+    tooltipVisible: leftVisible,
+  } = useTooltip('I should not touch the edge of the screen', { placement: 'top', trigger: 'click' });
+  const {
+    targetRef: targetRefRight,
+    tooltip: tooltipRight,
+    tooltipVisible: rightVisible,
+  } = useTooltip('I should not touch the edge of the screen', { placement: 'top', trigger: 'click' });
+  const {
+    targetRef: targetRefMiddle,
+    tooltip: tooltipMiddle,
+    tooltipVisible: middleVisible,
+  } = useTooltip('I should not touch the edge of the screen', { placement: 'top', trigger: 'click' });
   return (
     <div style={{ padding: '16px', height: '800px', backgroundColor: '#EEE' }}>
       <Text>
@@ -300,6 +315,32 @@ export const ScreenEdges: React.FC = () => {
         </span>
         {rightVisible && tooltipRight}
       </div>
+    </div>
+  );
+};
+
+export const ThemeInversion: React.FC = () => {
+  const tooltipContent = (
+    <>
+      <Text>Tooltips have inverted theme</Text>
+      <Toggle />
+      <BalanceInput value="1.0" currencyValue="~623.45 USD" placeholder="0.0" />
+    </>
+  );
+  const { targetRef, tooltip } = useTooltip(tooltipContent, { placement: 'bottom' });
+  return (
+    <div style={{ padding: '60px 25px', width: '550px', display: 'flex', gap: '15px' }}>
+      <div style={{ flex: '1' }}>
+        <Text>Current theme looks like this</Text>
+        <Toggle />
+        <BalanceInput value="1.0" currencyValue="~623.45 USD" placeholder="0.0" />
+      </div>
+      <div style={{ flex: '1', textAlign: 'center' }}>
+        <span ref={targetRef}>
+          <HelpIcon />
+        </span>
+      </div>
+      {tooltip}
     </div>
   );
 };

--- a/src/hooks/useTooltip/useTooltip.tsx
+++ b/src/hooks/useTooltip/useTooltip.tsx
@@ -1,38 +1,84 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Placement, Padding } from '@popperjs/core';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { usePopper } from 'react-popper';
+import { ThemeProvider, DefaultTheme } from 'styled-components';
+import { light, dark } from '../../theme';
 import { StyledTooltip, Arrow } from './StyledTooltip';
-import { TooltipRefs, TriggerType } from './types';
+import { TooltipOptions, TooltipRefs } from './types';
 
 function isTouchDevice() {
   return 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
 }
 
-const useTooltip = (
-  content: React.ReactNode,
-  placement: Placement = 'auto',
-  trigger: TriggerType = 'hover',
-  arrowPadding?: Padding,
-  tooltipPadding?: Padding,
-  tooltipOffset?: [number, number]
-): TooltipRefs => {
+const invertTheme = (currentTheme: DefaultTheme) => {
+  if (currentTheme.isDark) {
+    return light;
+  }
+  return dark;
+};
+
+const useTooltip = (content: React.ReactNode, options: TooltipOptions): TooltipRefs => {
+  const {
+    placement = 'auto',
+    trigger = 'hover',
+    arrowPadding = 16,
+    tooltipPadding = { left: 16, right: 16 },
+    tooltipOffset = [0, 10],
+  } = options;
   const [targetElement, setTargetElement] = useState<HTMLElement | null>(null);
   const [tooltipElement, setTooltipElement] = useState<HTMLElement | null>(null);
   const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
 
   const [visible, setVisible] = useState(false);
+  const isHoveringOverTooltip = useRef(false);
+  const hideTimeout = useRef<number>();
 
-  const hideTooltip = useCallback((e: Event) => {
-    e.stopPropagation();
-    e.preventDefault();
-    setVisible(false);
-  }, []);
+  const hideTooltip = useCallback(
+    (e: Event) => {
+      const hide = () => {
+        e.stopPropagation();
+        e.preventDefault();
+        setVisible(false);
+      };
 
-  const showTooltip = useCallback((e: Event) => {
-    e.stopPropagation();
-    e.preventDefault();
-    setVisible(true);
-  }, []);
+      if (trigger === 'hover') {
+        if (hideTimeout.current) {
+          window.clearTimeout(hideTimeout.current);
+        }
+        if (e.target === tooltipElement) {
+          isHoveringOverTooltip.current = false;
+        }
+        if (!isHoveringOverTooltip.current) {
+          hideTimeout.current = window.setTimeout(() => {
+            if (!isHoveringOverTooltip.current) {
+              hide();
+            }
+          }, 100);
+        }
+      } else {
+        hide();
+      }
+    },
+    [tooltipElement, trigger]
+  );
+
+  const showTooltip = useCallback(
+    (e: Event) => {
+      e.stopPropagation();
+      e.preventDefault();
+      setVisible(true);
+      if (trigger === 'hover') {
+        if (e.target === targetElement) {
+          // If we were about to close the tooltip and got back to it
+          // then prevent closing it.
+          clearTimeout(hideTimeout.current);
+        }
+        if (e.target === tooltipElement) {
+          isHoveringOverTooltip.current = true;
+        }
+      }
+    },
+    [tooltipElement, targetElement, trigger]
+  );
 
   const toggleTooltip = useCallback(
     (e: Event) => {
@@ -130,16 +176,16 @@ const useTooltip = (
     modifiers: [
       {
         name: 'arrow',
-        options: { element: arrowElement, padding: arrowPadding || 16 },
+        options: { element: arrowElement, padding: arrowPadding },
       },
-      { name: 'offset', options: { offset: tooltipOffset || [0, 10] } },
-      { name: 'preventOverflow', options: { padding: tooltipPadding || { left: 16, right: 16 } } },
+      { name: 'offset', options: { offset: tooltipOffset } },
+      { name: 'preventOverflow', options: { padding: tooltipPadding } },
     ],
   });
 
   const tooltip = (
     <StyledTooltip ref={setTooltipElement} style={styles.popper} {...attributes.popper}>
-      {content}
+      <ThemeProvider theme={invertTheme}>{content}</ThemeProvider>
       <Arrow ref={setArrowElement} style={styles.arrow} />
     </StyledTooltip>
   );


### PR DESCRIPTION
In this PR:

hasTooltip prop for <Text /> to show dotted underline
Use object for useTooltip arguments instead of separate parameters.
Invert the theme of child components in the tooltip
Slight improvement to hover delayed hide logic.
