### PR TITLE
fix: Rename ColorKey

### DIFF
--- a/src/components/ButtonMenu/ButtonMenuItem.tsx
+++ b/src/components/ButtonMenu/ButtonMenuItem.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
+
 import Button from '../Button/Button';
 import { BaseButtonProps, PolymorphicComponent, variants } from '../Button/types';
 import { ButtonMenuItemProps } from './types';
 
 interface InactiveButtonProps extends BaseButtonProps {
   forwardedAs: BaseButtonProps['as'];
-  colorKey: 'primary' | 'textSubtle';
+  colorkey: 'primary' | 'textSubtle';
 }
 
 const InactiveButton: PolymorphicComponent<InactiveButtonProps, 'button'> = styled(Button)<InactiveButtonProps>`
   background-color: transparent;
-  color: ${({ theme, colorKey }) => theme.colors[colorKey]};
+  color: ${({ theme, colorkey }) => theme.colors[colorkey]};
   &:hover:not(:disabled):not(:active) {
     background-color: transparent;
   }
@@ -28,7 +29,7 @@ const ButtonMenuItem: PolymorphicComponent<ButtonMenuItemProps, 'button'> = ({
       <InactiveButton
         forwardedAs={as}
         variant="tertiary"
-        colorKey={variant === variants.PRIMARY ? 'primary' : 'textSubtle'}
+        colorkey={variant === variants.PRIMARY ? 'primary' : 'textSubtle'}
         {...props}
       />
     );

--- a/src/components/Tag/StyledTag.tsx
+++ b/src/components/Tag/StyledTag.tsx
@@ -11,8 +11,8 @@ interface ThemedProps extends TagProps {
 
 const getOutlineStyles = ({ outline, theme, variant: variantKey = variants.PRIMARY }: ThemedProps) => {
   if (outline) {
-    const themeColorKey = styleVariants[variantKey].backgroundColor as keyof Colors;
-    const color = theme.colors[themeColorKey];
+    const themeColorkey = styleVariants[variantKey].backgroundColor as keyof Colors;
+    const color = theme.colors[themeColorkey];
 
     return `
       color: ${color};


### PR DESCRIPTION
We have a warning in frontend, I think this can avoid it
Warning: 
<img width="559" alt="Screenshot 2021-05-28 at 18 42 13" src="https://user-images.githubusercontent.com/32134460/120016058-6dc4e100-bfe4-11eb-849b-c54e06566b12.png">

